### PR TITLE
Added guard around Bintray credentials in Gradle config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ version = '0.5.10'
 group = 'net.devrieze'
 
 bintray {
-    user = bintrayUser
-    key = bintrayApiKey
+    user = project.findProperty('bintrayUser') ?: ''
+    key = project.findProperty('bintrayApiKey') ?: ''
     publications = ['MyPublication']
 
     pkg {


### PR DESCRIPTION
* Previously the Bintray credentials were set using variables which were
not set in a clean clone of the repo
* These variables are now guaded so that the configuration phase of the
Gradle build can complete without the need for publication credentials

Related to issue #2 